### PR TITLE
Fix CLI update option check

### DIFF
--- a/server/cli.js
+++ b/server/cli.js
@@ -126,7 +126,9 @@ program
         tags: options.tags ? options.tags.split(',').map(tag => tag.trim()) : existingPrompt.tags
       };
 
-      if (Object.keys(options).length === 0) {
+      // Commander always provides the option keys, even if the user did not
+      // supply values. Check each field explicitly to detect a no-op update.
+      if (!options.title && !options.content && !options.category && !options.tags) {
          console.log(chalk.yellow('No update options provided. Use -h for help.'));
          return;
       }


### PR DESCRIPTION
## Summary
- fix check in CLI `update` command to detect no provided options

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fbd4ffb54832186d563f06e4fa9d1