### PR TITLE
Improve version history UI

### DIFF
--- a/client/src/components/PromptDetail.js
+++ b/client/src/components/PromptDetail.js
@@ -12,6 +12,20 @@ function PromptDetail({ categories, onPromptDeleted }) {
   const [loading, setLoading] = useState(true);
   const [showVersionHistory, setShowVersionHistory] = useState(false);
 
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        setShowVersionHistory(false);
+      }
+    };
+    if (showVersionHistory) {
+      window.addEventListener('keydown', handleKey);
+    }
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [showVersionHistory]);
+
   const loadPrompt = useCallback(async () => {
     try {
       setLoading(true);
@@ -202,15 +216,21 @@ function PromptDetail({ categories, onPromptDeleted }) {
 
       {/* Version History */}
       {showVersionHistory && (
-        <div className="mt-6">
-          <VersionHistory
-            prompt={prompt}
-            onVersionRestore={() => {
-              loadPrompt();
-              setShowVersionHistory(false);
-            }}
-            onClose={() => setShowVersionHistory(false)}
+        <div className="fixed inset-0 z-40 flex">
+          <div
+            className="absolute inset-0 bg-black bg-opacity-50"
+            onClick={() => setShowVersionHistory(false)}
           />
+          <div className="relative ml-auto w-full max-w-xl h-full bg-white shadow-xl slide-in-right overflow-y-auto">
+            <VersionHistory
+              prompt={prompt}
+              onVersionRestore={() => {
+                loadPrompt();
+                setShowVersionHistory(false);
+              }}
+              onClose={() => setShowVersionHistory(false)}
+            />
+          </div>
         </div>
       )}
 

--- a/client/src/components/VersionHistory.js
+++ b/client/src/components/VersionHistory.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Clock, RotateCcw, ArrowLeft, Calendar, User, MessageSquare } from 'lucide-react';
+import { Clock, RotateCcw, X, Calendar, MessageSquare } from 'lucide-react';
 import { promptsApi } from '../services/api';
 import toast from 'react-hot-toast';
 
@@ -83,32 +83,31 @@ function VersionHistory({ prompt, onVersionRestore, onClose }) {
 
   if (loading) {
     return (
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <div className="flex items-center justify-center py-8">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-        </div>
+      <div className="p-6 flex items-center justify-center h-full">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
       </div>
     );
   }
 
   return (
     <>
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200">
-        <div className="p-6">
-          <div className="flex items-center justify-between mb-6">
-            <div className="flex items-center space-x-3">
-              <Clock className="h-5 w-5 text-gray-600" />
-              <h2 className="text-lg font-medium text-gray-900">Version History</h2>
-            </div>
-            {onClose && (
-              <button
-                onClick={onClose}
-                className="text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeft className="h-5 w-5" />
-              </button>
-            )}
+      <div className="flex flex-col h-full">
+        <div className="flex items-center justify-between p-6 border-b">
+          <div className="flex items-center space-x-3">
+            <Clock className="h-5 w-5 text-gray-600" />
+            <h2 className="text-lg font-medium text-gray-900">Version History</h2>
           </div>
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          )}
+        </div>
+
+        <div className="p-6 overflow-y-auto flex-1">
 
           {versions.length === 0 ? (
             <div className="text-center py-8 text-gray-500">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -24,4 +24,14 @@
   .textarea-field {
     @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none;
   }
-} 
+
+}
+@layer utilities {
+  @keyframes slide-in-right {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+  }
+  .slide-in-right {
+    animation: slide-in-right 0.3s ease-out forwards;
+  }
+}


### PR DESCRIPTION
## Summary
- add slide-in animation utility in Tailwind CSS
- display version history as a slide-over panel with close button
- dismiss version history with Esc key or overlay click

## Testing
- `npm --prefix client test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_683fc4000c7883218c1d8eef007d82a4