### PR TITLE
Add Jest-based test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "client": "cd client && npm start",
     "build": "cd client && npm run build",
     "start": "cd server && npm start",
-    "install-all": "npm install && cd server && npm install && cd ../client && npm install"
+    "install-all": "npm install && cd server && npm install && cd ../client && npm install",
+    "test": "client/node_modules/.bin/jest"
   },
   "keywords": [
     "llm",
@@ -20,7 +21,9 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "concurrently": "^8.2.2"
+    "concurrently": "^8.2.2",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/server/__tests__/db.test.js
+++ b/server/__tests__/db.test.js
@@ -1,0 +1,60 @@
+process.env.DB_PATH = ':memory:';
+const db = require('../db');
+
+beforeAll(async () => {
+  await db.setupDatabase();
+});
+
+afterAll(async () => {
+  await db.closeDb();
+});
+
+describe('database module', () => {
+  test('create and fetch prompt', async () => {
+    const prompt = await db.createPrompt({
+      title: 'Test',
+      content: 'Hello world',
+      category: 'General',
+      tags: ['tag1', 'tag2']
+    });
+
+    const fetched = await db.getPromptById(prompt.id);
+    expect(fetched.title).toBe('Test');
+    expect(fetched.content).toBe('Hello world');
+    expect(fetched.tags).toEqual(['tag1', 'tag2']);
+  });
+
+  test('updatePrompt stores previous version', async () => {
+    const prompt = await db.createPrompt({
+      title: 'VersionTest',
+      content: 'Original',
+      category: null,
+      tags: []
+    });
+
+    await db.updatePrompt(prompt.id, {
+      title: 'VersionTest',
+      content: 'Updated',
+      category: 'Test',
+      tags: ['a'],
+      change_reason: 'update'
+    });
+
+    const versions = await db.getPromptVersions(prompt.id);
+    expect(versions.length).toBe(1);
+    expect(versions[0].content).toBe('Original');
+  });
+
+  test('deletePrompt removes prompt', async () => {
+    const prompt = await db.createPrompt({
+      title: 'Delete',
+      content: 'To be removed',
+      category: null,
+      tags: []
+    });
+
+    const deleted = await db.deletePrompt(prompt.id);
+    expect(deleted).toBe(true);
+    await expect(db.getPromptById(prompt.id)).rejects.toThrow();
+  });
+});

--- a/server/db.js
+++ b/server/db.js
@@ -2,7 +2,8 @@ const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 const { v4: uuidv4 } = require('uuid');
 
-const dbPath = path.join(__dirname, 'prompts.db');
+// Allow overriding the database path for tests or custom setups
+const dbPath = process.env.DB_PATH || path.join(__dirname, 'prompts.db');
 let db;
 
 // Internal helper to resolve a prompt ID (full or prefix)


### PR DESCRIPTION
## Summary
- allow overriding DB path through `DB_PATH` environment variable
- add Jest testing script to root package.json
- implement `server/__tests__/db.test.js` for core database features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc943f55083218afddc855703f576